### PR TITLE
支持微信 4.x 防撤回（build 268880 / 4.1.10，patch wechat.dylib）

### DIFF
--- a/Sources/WeChatTweak/Command.swift
+++ b/Sources/WeChatTweak/Command.swift
@@ -23,11 +23,33 @@ struct Command {
         try await Command.execute(command: "defaults read \(app.appendingPathComponent("Contents/Info.plist").path) CFBundleVersion")
     }
 
-    static func patch(app: URL, config: Config) async throws {
-        try Patcher.patch(binary: app.appendingPathComponent("Contents/MacOS/WeChat"), config: config)
+    static let defaultBinary = "Contents/MacOS/WeChat"
+
+    /// Patches every target into its own binary (default `Contents/MacOS/WeChat`;
+    /// WeChat 4.x targets `Contents/Resources/wechat.dylib`). Returns the unique
+    /// bundle-relative paths that were touched, so `resign` can sign them first.
+    @discardableResult
+    static func patch(app: URL, config: Config) throws -> [String] {
+        var patched: [String] = []
+        for target in config.targets {
+            let relative = target.binary ?? Command.defaultBinary
+            print("------ Target: \(target.identifier) (\(relative)) ------")
+            try Patcher.patch(binary: app.appendingPathComponent(relative), entries: target.entries)
+            if !patched.contains(relative) {
+                patched.append(relative)
+            }
+        }
+        return patched
     }
 
-    static func resign(app: URL) async throws {
+    static func resign(app: URL, patchedBinaries: [String] = []) async throws {
+        // Sign each patched nested binary first, so a modified dylib already carries
+        // a valid ad-hoc signature before the app-level --deep re-sign wraps it.
+        // Otherwise the running app can hit `Code Signature Invalid` on the patched page.
+        for relative in patchedBinaries where relative != Command.defaultBinary {
+            let path = app.appendingPathComponent(relative).path
+            try await Command.execute(command: "codesign --force --sign - \(path)")
+        }
         try await Command.execute(command: "codesign --remove-sign \(app.path)")
         try await Command.execute(command: "codesign --force --deep --sign - \(app.path)")
         try await Command.execute(command: "xattr -cr \(app.path)")

--- a/Sources/WeChatTweak/Config.swift
+++ b/Sources/WeChatTweak/Config.swift
@@ -27,11 +27,15 @@ struct Config: Decodable {
         let arch: Arch
         let addr: UInt64
         let asm: Data
+        /// Original bytes expected at `addr` before patching. May list several
+        /// accepted variants (e.g. pristine + already-patched). Empty = skip check.
+        let expected: [Data]
 
         private enum CodingKeys: CodingKey {
             case arch
             case addr
             case asm
+            case expected
         }
 
         init(from decoder: any Decoder) throws {
@@ -59,22 +63,47 @@ struct Config: Decodable {
                 }
                 return value
             }()
+            self.expected = try {
+                // `expected` may be absent, a single hex string, or an array of them.
+                guard container.contains(.expected) else { return [] }
+                let hexes: [String]
+                if let single = try? container.decode(String.self, forKey: .expected) {
+                    hexes = [single]
+                } else {
+                    hexes = try container.decode([String].self, forKey: .expected)
+                }
+                return try hexes.map { hex in
+                    guard let value = Data(hex: hex) else {
+                        throw DecodingError.dataCorruptedError(
+                            forKey: CodingKeys.expected,
+                            in: container,
+                            debugDescription: "Invalid Entry.expected"
+                        )
+                    }
+                    return value
+                }
+            }()
         }
     }
 
     struct Target: Decodable {
         let identifier: String
         let entries: [Entry]
+        /// Bundle-relative path of the binary to patch. `nil` → `Contents/MacOS/WeChat`.
+        /// WeChat 4.x moved the revoke logic into `Contents/Resources/wechat.dylib`.
+        let binary: String?
 
         private enum CodingKeys: CodingKey {
             case identifier
             case entries
+            case binary
         }
 
         init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.identifier = try container.decode(String.self, forKey: .identifier)
             self.entries = try container.decode([Entry].self, forKey: .entries)
+            self.binary = try container.decodeIfPresent(String.self, forKey: .binary)
         }
     }
 

--- a/Sources/WeChatTweak/Patcher.swift
+++ b/Sources/WeChatTweak/Patcher.swift
@@ -10,19 +10,34 @@ import MachO
 import Foundation
 
 struct Patcher {
-    enum Error: Swift.Error {
+    enum Error: LocalizedError {
         case invalidFile
         case not64BitMachO(magic: UInt32)
         case vaNotFound(arch: String, va: UInt64)
         case noArchMatched
+        case expectedMismatch(arch: String, va: UInt64, found: String, want: [String])
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFile:
+                return "Invalid binary file"
+            case let .not64BitMachO(magic):
+                return "Not a 64-bit Mach-O (magic: \(String(format: "0x%08x", magic)))"
+            case let .vaNotFound(arch, va):
+                return "[\(arch)] VA \(String(format: "0x%llx", va)) not found in any segment"
+            case .noArchMatched:
+                return "No matching arch/entries to patch"
+            case let .expectedMismatch(arch, va, found, want):
+                return "[\(arch)] byte mismatch at \(String(format: "0x%llx", va)): found \(found), expected one of \(want.joined(separator: " / ")). Wrong WeChat build — refusing to patch."
+            }
+        }
     }
 
-    static func patch(binary: URL, config: Config) throws {
+    static func patch(binary: URL, entries: [Config.Entry]) throws {
         guard FileManager.default.fileExists(atPath: binary.path) else {
             throw Error.invalidFile
         }
 
-        let entries = config.targets.flatMap { $0.entries }
         guard !entries.isEmpty else { throw Error.noArchMatched }
 
         let fh = try FileHandle(forUpdating: binary)
@@ -66,6 +81,7 @@ struct Patcher {
                                       sliceOffset: UInt64(entry.offset),
                                       targetVA: target.addr,
                                       patch: target.asm,
+                                      expected: target.expected,
                                       archName: target.arch.rawValue)
                     patchedCount += 1
                 }
@@ -93,6 +109,7 @@ struct Patcher {
                                   sliceOffset: 0,
                                   targetVA: target.addr,
                                   patch: target.asm,
+                                  expected: target.expected,
                                   archName: target.arch.rawValue)
                 patchedCount += 1
             }
@@ -107,6 +124,7 @@ struct Patcher {
                                       sliceOffset: UInt64,
                                       targetVA: UInt64,
                                       patch: Data,
+                                      expected: [Data],
                                       archName: String) throws {
 
         // 读 slice 内 mach_header_64
@@ -144,8 +162,25 @@ struct Patcher {
 
                 if vmaddr <= targetVA && targetVA < vmaddr + vmsize {
                     let fileOffset = sliceOffset + fileoff + (targetVA - vmaddr)
-                    print("[\(archName)] vmaddr=\(String(format: "0x%llx", vmaddr)), fileoff=\(String(format: "0x%llx", fileoff)), sliceoff=\(String(format: "0x%llx", sliceOffset))")
-                    print("[\(archName)] patch VA=\(String(format: "0x%llx", targetVA)), fileoff=\(String(format: "0x%llx", fileOffset))")
+
+                    // Read current bytes to guard against patching the wrong build.
+                    try fh.seek(toOffset: fileOffset)
+                    let current = try fh.read(upToCount: patch.count) ?? Data()
+
+                    if current == patch {
+                        print("[\(archName)] VA \(String(format: "0x%llx", targetVA)) already patched — skipping")
+                        return
+                    }
+                    if !expected.isEmpty && !expected.contains(current) {
+                        throw Error.expectedMismatch(
+                            arch: archName,
+                            va: targetVA,
+                            found: current.map { String(format: "%02X", $0) }.joined(),
+                            want: expected.map { $0.map { String(format: "%02X", $0) }.joined() }
+                        )
+                    }
+
+                    print("[\(archName)] patch VA=\(String(format: "0x%llx", targetVA)), fileoff=\(String(format: "0x%llx", fileOffset)): \(current.map { String(format: "%02X", $0) }.joined()) -> \(patch.map { String(format: "%02X", $0) }.joined())")
 
                     try fh.seek(toOffset: fileOffset)
                     try fh.write(contentsOf: patch)

--- a/Sources/WeChatTweak/main.swift
+++ b/Sources/WeChatTweak/main.swift
@@ -46,7 +46,7 @@ extension Tweak {
             print("Matched config: \(config)")
 
             print("------ Patch ------")
-            try await Command.patch(
+            let patched = try Command.patch(
                 app: options.app,
                 config: config
             )
@@ -54,7 +54,8 @@ extension Tweak {
 
             print("------ Resign ------")
             try await Command.resign(
-                app: options.app
+                app: options.app,
+                patchedBinaries: patched
             )
             print("Done!")
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "268880",
+    "targets": [
+      {
+        "identifier": "revoke",
+        "binary": "Contents/Resources/wechat.dylib",
+        "entries": [
+          {
+            "arch": "arm64",
+            "addr": "48831a0",
+            "expected": "E00F0034",
+            "asm": "7F000014"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "version": "31927",
     "targets": [
       {


### PR DESCRIPTION
## 背景

微信 4.x 把消息撤回逻辑从主二进制搬进了 `Contents/Resources/wechat.dylib`（strip 过的 C++ 内核）。当前工具按写死的路径 patch `Contents/MacOS/WeChat`，在 4.x 上打不到任何撤回代码，所以每个 4.x 构建号都报 unsupported。

本 PR 在**不改动 3.8.x 行为**的前提下加上 4.x 支持。

## 改动

- **`Config.Target` 新增可选 `binary`**（bundle 相对路径，缺省 `Contents/MacOS/WeChat`）；**`Config.Entry` 新增可选 `expected`**（打补丁前的原始字节，单个 hex 串或数组）。现有 config 条目都不带这两个字段 → 解析和行为与之前完全一致。
- **`Patcher` 写前校验字节**：已是目标值 → 幂等跳过；与 `expected` 不符 → 直接报错拒写（打错版本不会被盲写搞坏），而不是无脑覆盖。
- **`Command.patch` 按 target 的 `binary` 分组分别打补丁**；`resign` 先单独 ad-hoc 签被改的 dylib，再 `--deep` 签整个 App，避免运行到被改代码页时 `Code Signature Invalid`。
- **`config.json` 新增 build 268880（微信 4.1.10）** 的 `revoke` target：`wechat.dylib` `0x48831a0`，`cbz w0 E00F0034` → `b 7F000014`。

## 补丁点来源

`parseRevokeXML` 入口附近有条 `cbz w0`，w0 是"是否执行撤回"的判定；把它改成无条件 `b`（目标地址不变）后永远跳过删除逻辑，消息保留、静默无提示。

地址通过 `parseRevokeXML` 的几何特征定位（入口 `stp` 序言 + `entry+0x270` 的 `cbz w0` + `entry+0xA04` 的 `str x0,[x19,#0x168]`），在整个 arm64 切片里**唯一命中**，经反汇编与原始字节逐一核对，并已在真实微信 4.1.10 上**实测撤回被拦生效**。

逆向方法参考 [fzlzjerry/wechat-antirecall](https://github.com/fzlzjerry/wechat-antirecall)。

## 范围

本 PR 只加 268880 的防撤回。多开在 4.x 上没有可字节 patch 的开关（需整包复制 App），阻止更新未包含在内。其它 4.x 构建号可照 config 里的模式继续补（几何特征跨版本稳定）。

已 `swift build -c release` 通过。